### PR TITLE
feat(nats): add option to build for NATS message bus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM golang:1.18-alpine3.16 AS builder
+FROM golang:1.18-alpine3.17 AS builder
 WORKDIR /device-opcua-go
 
 # Install our build time packages.
@@ -16,10 +16,11 @@ RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
 
-RUN make build
+ARG ADD_BUILD_TAGS=""
+RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS build
 
 # Next image - Copy built Go binary into new workspace
-FROM alpine:3.16
+FROM alpine:3.17
 
 # dumb-init needed for injected secure bootstrapping entrypoint script when run in secure mode.
 RUN apk add --update --no-cache zeromq dumb-init

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,11 @@ tidy:
 
 build: $(MICROSERVICES)
 
+build-nats:
+	make -e ADD_BUILD_TAGS=include_nats_messaging build
+
 cmd/device-opcua:
-	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd
+	$(GOCGO) build -tags "$(ADD_BUILD_TAGS)" $(CGOFLAGS) -o $@ ./cmd
 
 unittest:
 	$(GOCGO) test ./... -coverprofile=coverage.out ./...
@@ -57,9 +60,13 @@ docker: $(DOCKERS)
 docker_device_opcua_go:
 	docker build \
 		--label "git_sha=$(GIT_SHA)" \
-		-t edgexfoundry/device-opcua-go:$(GIT_SHA) \
-		-t edgexfoundry/device-opcua-go:$(VERSION)-dev \
+		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
+		-t edgexfoundry/device-opcua-goa:$(GIT_SHA) \
+		-t edgexfoundry/device-opcua-goa:$(VERSION)-dev \
 		.
+
+docker-nats:
+	make -e ADD_BUILD_TAGS=include_nats_messaging docker
 
 vendor:
 	$(GO) mod vendor

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ docker_device_opcua_go:
 	docker build \
 		--label "git_sha=$(GIT_SHA)" \
 		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
-		-t edgexfoundry/device-opcua-goa:$(GIT_SHA) \
-		-t edgexfoundry/device-opcua-goa:$(VERSION)-dev \
+		-t edgexfoundry/device-opcua-go:$(GIT_SHA) \
+		-t edgexfoundry/device-opcua-go:$(VERSION)-dev \
 		.
 
 docker-nats:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ EDGEX_SECURITY_SECRET_STORE=false make run
 make docker
 ```
 
+## Build with NATS Messaging
+
+Currently, the NATS Messaging capability (NATS MessageBus) is opt-in at build time. This means that the published Docker image and Snaps do not include the NATS messaging capability.
+
+The following make commands will build the local binary or local Docker image with NATS messaging capability included.
+
+```bash
+make build-nats
+make docker-nats
+```
+
+The locally built Docker image can then be used in place of the published Docker image in your compose file.
+See [Compose Builder](https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder#gen) `nat-bus` option to generate compose file for NATS and local dev images.
+
 ## Testing
 
 Running unit tests starts a mock OPCUA server on port `48408`.

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -1,11 +1,22 @@
+MaxEventSize = 0 
+
 [Service]
 HealthCheckInterval = "10s"
 Host = "localhost"
 Port = 59997
-ServerBindAddr = ""
+ServerBindAddr = ""  # blank value defaults to Service.Host value
 StartupMsg = "device opcua started"
-MaxRequestSize = 0
+# MaxRequestSize limit the request body size in byte of put command
+MaxRequestSize = 0 # value 0 unlimited request size.
 RequestTimeout = "5s"
+  [Service.CORSConfiguration]
+  EnableCORS = false
+  CORSAllowCredentials = false
+  CORSAllowedOrigin = "https://localhost"
+  CORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE"
+  CORSAllowedHeaders = "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+  CORSExposeHeaders = "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+  CORSMaxAge = 3600
 
 [Registry]
 Host = "localhost"
@@ -34,6 +45,9 @@ Type = "redis"
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
 PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
+  [MessageQueue.Topics]
+  CommandRequestTopic = "edgex/device/command/request/device-opcua/#"   # subscribing for inbound command requests
+  CommandResponseTopicPrefix = "edgex/device/command/response"   # publishing outbound command responses; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
   [MessageQueue.Optional]
   # Default MQTT Specific options that need to be here to enable environment variable overrides of them
   # Client Identifiers
@@ -66,9 +80,19 @@ Path = "device-opcua/"
 Protocol = "http"
 RootCaCertPath = ""
 ServerName = ""
+SecretsFile = ""
+DisableScrubSecretsFile = false
 TokenFile = "/tmp/edgex/secrets/device-opcua/secrets-token.json"
   [SecretStore.Authentication]
   AuthType = "X-Vault-Token"
+  [SecretStore.RuntimeTokenProvider]
+  Enabled = false
+  Protocol = "https"
+  Host = "localhost"
+  Port = 59841
+  TrustDomain = "edgexfoundry.org"
+  EndpointSocket = "/tmp/edgex/secrets/spiffe/public/api.sock"
+  RequiredSecrets = "redisdb"
 
 [Writable]
 LogLevel = "INFO"
@@ -79,3 +103,19 @@ LogLevel = "INFO"
       [Writable.InsecureSecrets.Sample.Secrets]
       username = ""
       password = ""
+  [Writable.Reading]
+  ReadingUnits = true
+  [Writable.Telemetry]
+    Interval = "30s"
+    PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
+      [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
+      # Device SDK provided Service Metrics
+      EventsSent = false
+      ReadingsSent = false
+      # Common Security Service Metrics
+      SecuritySecretsRequested = false
+      SecuritySecretsStored = false
+      SecurityConsulTokensRequested = false
+      SecurityConsulTokenDuration = false
+      [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
+  #    Gateway="my-iot-gateway" # Tag must be added here since Env Override can only change existing value, not added new ones.


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) No code changes
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions

<!-- How can the reviewers test your change? -->
Do a `make docker-nats` and follow `edgex-go`'s guide to set the NATS message bus. You should have a log message like below.
```sh
level=INFO ts=2023-05-01T13:33:20.271494321Z app=device-opcua source=httpserver.go:133 msg="Web server starting (edgex-device-opcua:59997)"
level=INFO ts=2023-05-01T13:33:20.272501668Z app=device-opcua source=messaging.go:104 msg="Connected to nats-jetstream Message Bus @ tcp://edgex-nats-server:4222 publishing on 'edgex/events/device' prefix topic with AuthMode='none'"
```

## New Dependency Instructions (If applicable)

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
