### PR TITLE
fix: use nano timestamp

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -213,3 +213,6 @@ https://github.com/nats-io/nats.go/blob/main/LICENSE
 
 github.com/nats-io/nuid (Apache-2.0) https://github.com/nats-io/nuid
 https://github.com/nats-io/nuid/blob/master/LICENSE
+
+github.com/gabriel-vasile/mimetype (MIT) https://github.com/gabriel-vasile/mimetype
+https://github.com/gabriel-vasile/mimetype/blob/master/LICENSE

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -99,7 +99,7 @@ func NewResult(req sdkModel.CommandRequest, reading interface{}) (*sdkModel.Comm
 	if err != nil {
 		return nil, err
 	}
-	result.Origin = time.Now().UnixNano() / int64(time.Millisecond)
+	result.Origin = time.Now().UnixNano()
 
 	return result, err
 }


### PR DESCRIPTION
- Make `origin` value consistent with other EdgeX device services
- Add missing attribution reference