### PR TITLE
fix: subscriptions and method calls with state and mode

### DIFF
--- a/internal/server/methodhandler.go
+++ b/internal/server/methodhandler.go
@@ -14,6 +14,15 @@ import (
 )
 
 func (s *Server) ProcessMethodCall(method string, parameters []string) (interface{}, error) {
+	device, err := s.sdk.GetDeviceByName(s.deviceName)
+	if err != nil {
+		return nil, fmt.Errorf("device not found: %v", err)
+	}
+
+	if device.AdminState == models.Locked || device.OperatingState == models.Down {
+		return nil, fmt.Errorf("method [%s] not processed for [%s]: device is locked or down", method, s.deviceName)
+	}
+
 	resource, ok := s.sdk.DeviceResource(s.deviceName, method)
 	if !ok {
 		return nil, fmt.Errorf("method not found")

--- a/internal/server/methodhandler_test.go
+++ b/internal/server/methodhandler_test.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -19,21 +20,48 @@ import (
 )
 
 func TestDriver_ProcessMethodCall(t *testing.T) {
+	okDevice := models.Device{
+		Name:           "TestDevice",
+		AdminState:     models.Unlocked,
+		OperatingState: models.Up,
+	}
 	type args struct {
+		device     models.Device
 		resource   models.DeviceResource
 		method     string
 		parameters []string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    interface{}
-		wantErr bool
+		name      string
+		args      args
+		deviceErr error
+		want      interface{}
+		wantErr   bool
 	}{
+		{
+			name:      "NOK - device not found",
+			deviceErr: fmt.Errorf("device not found"),
+			wantErr:   true,
+		},
+		{
+			name: "NOK - device locked",
+			args: args{
+				device: models.Device{AdminState: models.Locked},
+			},
+			wantErr: true,
+		},
+		{
+			name: "NOK - device down",
+			args: args{
+				device: models.Device{OperatingState: models.Down},
+			},
+			wantErr: true,
+		},
 		{
 			name: "NOK - method call - method not found",
 			args: args{
 				method: "TestResource0",
+				device: okDevice,
 			},
 			wantErr: true,
 		},
@@ -41,6 +69,7 @@ func TestDriver_ProcessMethodCall(t *testing.T) {
 			name: "NOK - method call - method is hidden",
 			args: args{
 				resource: models.DeviceResource{Name: "TestResource1", IsHidden: true},
+				device:   okDevice,
 			},
 			wantErr: true,
 		},
@@ -51,6 +80,7 @@ func TestDriver_ProcessMethodCall(t *testing.T) {
 					Name:       "TestResource1",
 					Attributes: map[string]interface{}{METHOD: "ns=2;s=test"},
 				},
+				device: okDevice,
 			},
 			wantErr: true,
 		},
@@ -61,6 +91,7 @@ func TestDriver_ProcessMethodCall(t *testing.T) {
 					Name:       "TestResource1",
 					Attributes: map[string]interface{}{OBJECT: "ns=2;s=main"},
 				},
+				device: okDevice,
 			},
 			wantErr: true,
 		},
@@ -74,6 +105,7 @@ func TestDriver_ProcessMethodCall(t *testing.T) {
 						OBJECT: "ns=2;s=main",
 					},
 				},
+				device: okDevice,
 			},
 			wantErr: true,
 		},
@@ -88,6 +120,7 @@ func TestDriver_ProcessMethodCall(t *testing.T) {
 					},
 				},
 				parameters: []string{"2"},
+				device:     okDevice,
 			},
 			want: "4",
 		},
@@ -116,7 +149,10 @@ func TestDriver_ProcessMethodCall(t *testing.T) {
 			dsMock := test.NewDSMock(t)
 			s := NewServer("test", dsMock)
 			s.client = &Client{client, context.Background()}
-			dsMock.On("DeviceResource", mock.Anything, tt.args.method).Return(tt.args.resource, tt.args.resource.Name != "")
+			dsMock.On("GetDeviceByName", mock.Anything).Return(tt.args.device, tt.deviceErr)
+			if tt.deviceErr == nil && tt.args.device.AdminState != models.Locked && tt.args.device.OperatingState != models.Down {
+				dsMock.On("DeviceResource", mock.Anything, tt.args.method).Return(tt.args.resource, tt.args.resource.Name != "")
+			}
 			got, err := s.ProcessMethodCall(tt.args.method, tt.args.parameters)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Driver.HandleReadCommands() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/server/subscriptionlistener.go
+++ b/internal/server/subscriptionlistener.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/edgexfoundry/device-opcua-go/pkg/result"
 	sdkModels "github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/ua"
 )
@@ -25,6 +26,11 @@ func (s *Server) StartSubscriptionListener() error {
 	device, err := s.sdk.GetDeviceByName(s.deviceName)
 	if err != nil {
 		return err
+	}
+
+	if device.AdminState == models.Locked || device.OperatingState == models.Down {
+		s.sdk.LoggingClient().Warnf("subscription listener not started for [%s]: device is locked or down", s.deviceName)
+		return nil
 	}
 
 	serverConfig, err := NewConfig(device.Protocols["opcua"])


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

Prior to this change, the reading of resources subscribed to OPC UA devices, along with the execution of OPC UA methods, were still possible even if the device was in a `LOCKED` or `DOWN` state. This makes sure that the device settings are checked prior to executing each functionality. Read and Write of resources are still handled by the inner workings of the Device SDK, as before.

# PR Checklist

Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
<!-- link to docs PR -->