### PR TITLE
fix: update policy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ deviceList:
     protocols:
       opcua:
         Endpoint: "opc.tcp://127.0.0.1:53530/OPCUA/SimulationServer"
-        # Security policy: None Basic128Rsa15 Basic256 Basic256Sha256 Aes128Sha256RsaOaep Aes256Sha256RsaPss. Default: None
+        # Security policy: None, Basic128Rsa15, Basic256, Basic256Sha256, Aes128Sha256RsaOaep, Aes256Sha256RsaPss. Default: None
         Policy: None
         # Security mode: None, Sign, SignAndEncrypt. Default: None
         Mode: None

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ deviceList:
     protocols:
       opcua:
         Endpoint: "opc.tcp://127.0.0.1:53530/OPCUA/SimulationServer"
-        # Security policy: None, Basic128Rsa15, Basic256, Basic256Sha256. Default: None
+        # Security policy: None Basic128Rsa15 Basic256 Basic256Sha256 Aes128Sha256RsaOaep Aes256Sha256RsaPss. Default: None
         Policy: None
         # Security mode: None, Sign, SignAndEncrypt. Default: None
         Mode: None

--- a/internal/driver/api_test.go
+++ b/internal/driver/api_test.go
@@ -105,7 +105,7 @@ func Test_handleMethodCall(t *testing.T) {
 			d, dsMock := newMockDriver(t)
 			if tt.deviceName != "" {
 				d.serverMap[tt.deviceName] = server.NewServer(tt.deviceName, dsMock)
-
+				dsMock.On("GetDeviceByName", tt.deviceName).Return(models.Device{Name: tt.deviceName}, nil)
 				dsMock.On("DeviceResource", tt.deviceName, tt.methodName).Return(tt.resource, true)
 			}
 			request, _ := http.NewRequest(http.MethodPost, "", tt.args.body)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -16,7 +16,7 @@ import (
 // Config struct details for OPCUA device list protocol properties
 type Config struct {
 	Endpoint  string   `json:"Endpoint" validate:"required"`
-	Policy    string   `json:"Policy" validate:"oneof=None Basic128Rsa15 Basic256 Basic256Sha256"`
+	Policy    string   `json:"Policy" validate:"oneof=None Basic128Rsa15 Basic256 Basic256Sha256 Aes128Sha256RsaOaep Aes256Sha256RsaPss"`
 	Mode      string   `json:"Mode" validate:"oneof=None Sign SignAndEncrypt"`
 	CertFile  string   `json:"CertFile" validate:"required_unless=Policy None Mode None"`
 	KeyFile   string   `json:"KeyFile" validate:"required_unless=Policy None Mode None"`


### PR DESCRIPTION
Adds missing allowed policies to the configuration: `Aes128Sha256RsaOaep` and `Aes256Sha256RsaPss`

Also fixes a unit test that was not passing.

<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions

<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
