### PR TITLE
fix: ignore reading value of nonexistent node

### DIFF
--- a/internal/server/readhandler.go
+++ b/internal/server/readhandler.go
@@ -61,6 +61,10 @@ func (s *Server) makeReadRequest(req sdkModel.CommandRequest) (*sdkModel.Command
 		return nil, fmt.Errorf("Driver.handleReadCommands: Status not OK: %v", resp.Results[0].Status)
 	}
 
-	reading := resp.Results[0].Value.Value()
-	return result.NewResult(req, reading)
+	variant := resp.Results[0].Value
+	if variant == nil {
+		return nil, fmt.Errorf("Driver.handleReadCommands: Variant value is nil")
+	}
+
+	return result.NewResult(req, variant.Value())
 }

--- a/internal/server/subscriptionlistener.go
+++ b/internal/server/subscriptionlistener.go
@@ -155,8 +155,15 @@ func (s *Server) handleDataChange(dcn *ua.DataChangeNotification) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	var data any
+
 	for _, item := range dcn.MonitoredItems {
-		data := item.Value.Value.Value()
+		variant := item.Value.Value
+		if variant != nil {
+			data = variant.Value()
+		} else {
+			continue
+		}
 		resourceName := s.resourceMap[item.ClientHandle]
 		if err := s.onIncomingDataReceived(data, resourceName); err != nil {
 			s.sdk.LoggingClient().Errorf("%v", err)

--- a/internal/server/subscriptionlistener.go
+++ b/internal/server/subscriptionlistener.go
@@ -155,9 +155,9 @@ func (s *Server) handleDataChange(dcn *ua.DataChangeNotification) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var data any
-
 	for _, item := range dcn.MonitoredItems {
+		var data any
+
 		variant := item.Value.Value
 		if variant != nil {
 			data = variant.Value()


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions
Attempt to read value from a nodeId that does not exist on the server.

Before the change, a fatal error and stack trace would occur. After the change, the reading is skipped.

## New Dependency Instructions (If applicable)

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
