### PR TITLE
fix: resolve crash when server-client connection is bad

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -89,12 +89,16 @@ func (d *Driver) UpdateDevice(deviceName string, protocols map[string]models.Pro
 // RemoveDevice is a callback function that is invoked
 // when a Device associated with this Device Service is removed
 func (d *Driver) RemoveDevice(deviceName string, protocols map[string]models.ProtocolProperties) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	d.sdk.LoggingClient().Debugf("Device %s is removed. Cleaning up...", deviceName)
 	if s, ok := d.serverMap[deviceName]; ok {
 		s.Cleanup(false)
 		d.serverMap[deviceName] = nil
 		return nil
 	}
+
 	return serverNotFoundError(deviceName)
 }
 
@@ -121,9 +125,9 @@ func (d *Driver) Start() error {
 // readings (if supported).
 func (d *Driver) Stop(force bool) error {
 	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.serverMap = nil
 	d.sdk = nil
-	d.mu.Unlock()
 	return nil
 }
 

--- a/internal/server/methodhandler.go
+++ b/internal/server/methodhandler.go
@@ -60,6 +60,12 @@ func (s *Server) makeMethodCall(resource models.DeviceResource, parameters []str
 		InputArguments: inputs,
 	}
 
+	if s.client == nil {
+		if err := s.Connect(); err != nil {
+			return nil, fmt.Errorf("Server.makeMethodCall: client not initialized: %s", err)
+		}
+	}
+
 	resp, err := s.client.Call(s.client.ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("Server.makeMethodCall: Method call failed: %s", err)

--- a/internal/server/readhandler.go
+++ b/internal/server/readhandler.go
@@ -53,6 +53,13 @@ func (s *Server) makeReadRequest(req sdkModel.CommandRequest) (*sdkModel.Command
 		},
 		TimestampsToReturn: ua.TimestampsToReturnBoth,
 	}
+
+	if s.client == nil {
+		if err := s.Connect(); err != nil {
+			return nil, fmt.Errorf("Driver.handleReadCommands: client not initialized: %s", err)
+		}
+	}
+
 	resp, err := s.client.Read(s.client.ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("Driver.handleReadCommands: Read failed: %s", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,6 +78,9 @@ func (s *Server) Connect() error {
 }
 
 func (s *Server) Cleanup(recreateContext bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.client != nil {
 		// Connection could have been opened from
 		// subscriptionlistener, readhandler, writehandler, or methodhandler

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,10 +8,13 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/edgexfoundry/device-sdk-go/v3/pkg/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/ua"
 )
 
 type CancelContext struct {
@@ -29,6 +32,7 @@ type Server struct {
 	resourceMap map[uint32]string
 	context     *CancelContext
 	client      *Client
+	config      *Config
 	sdk         interfaces.DeviceServiceSDK
 	mu          sync.Mutex
 }
@@ -43,7 +47,45 @@ func NewServer(deviceName string, sdk interfaces.DeviceServiceSDK) *Server {
 	return server
 }
 
+func (s *Server) Connect() error {
+	device, err := s.sdk.GetDeviceByName(s.deviceName)
+	if err != nil {
+		return err
+	}
+
+	if device.AdminState == models.Locked || device.OperatingState == models.Down {
+		return fmt.Errorf("client not started for [%s]: device is locked or down", s.deviceName)
+	}
+
+	serverConfig, err := NewConfig(device.Protocols["opcua"])
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.config = serverConfig
+	s.mu.Unlock()
+
+	if err := s.initClient(); err != nil {
+		return err
+	}
+
+	if err := s.client.Connect(s.client.ctx); err != nil {
+		s.sdk.LoggingClient().Warnf("[%s] failed to connect OPCUA client: %v", s.deviceName, err)
+		return err
+	}
+
+	return nil
+}
+
 func (s *Server) Cleanup(recreateContext bool) {
+	if s.client != nil {
+		// Connection could have been opened from
+		// subscriptionlistener, readhandler, writehandler, or methodhandler
+		if err := s.client.Close(s.client.ctx); err != nil {
+			s.sdk.LoggingClient().Warnf("[%s] failed to close OPCUA client: %v", s.deviceName, err)
+		}
+		s.client = nil
+	}
 	if s.context != nil {
 		s.context.cancel()
 		s.context = nil
@@ -61,4 +103,42 @@ func (s *Server) newContext() {
 		ctx:    ctx,
 		cancel: cancel,
 	}
+}
+
+func (s *Server) initClient() error {
+
+	endpoints, err := opcua.GetEndpoints(s.context.ctx, s.config.Endpoint)
+	if err != nil {
+		return err
+	}
+
+	ep := opcua.SelectEndpoint(endpoints, s.config.Policy, ua.MessageSecurityModeFromString(s.config.Mode))
+	if ep == nil {
+		return fmt.Errorf("[%s] failed to find suitable endpoint", s.deviceName)
+	}
+	ep.EndpointURL = s.config.Endpoint
+
+	opts := []opcua.Option{
+		opcua.SecurityPolicy(s.config.Policy),
+		opcua.SecurityModeString(s.config.Mode),
+		opcua.CertificateFile(s.config.CertFile),
+		opcua.PrivateKeyFile(s.config.KeyFile),
+		opcua.AuthAnonymous(),
+		opcua.SecurityFromEndpoint(ep, ua.UserTokenTypeAnonymous),
+	}
+
+	uaClient, err := opcua.NewClient(ep.EndpointURL, opts...)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.client = &Client{
+		uaClient,
+		context.Background(),
+	}
+
+	return nil
 }

--- a/internal/server/subscriptionlistener_test.go
+++ b/internal/server/subscriptionlistener_test.go
@@ -36,7 +36,8 @@ func Test_configureMonitoredItems(t *testing.T) {
 		dsMock.On("DeviceResource", "Test", "c").Return(models.DeviceResource{}, false)
 
 		s := NewServer("Test", dsMock)
-		err := s.configureMonitoredItems(nil, []string{"a", "b", "c"})
+		s.config = &Config{Resources: []string{"a", "b", "c"}}
+		err := s.configureMonitoredItems(nil)
 		if err != nil {
 			t.Errorf("expected no error, got = %v", err)
 		}
@@ -91,7 +92,8 @@ func TestDriver_initClient(t *testing.T) {
 				defer server.Close()
 			}
 
-			err := s.initClient(tt.config)
+			s.config = tt.config
+			err := s.initClient()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Driver.getClient() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/server/writehandler.go
+++ b/internal/server/writehandler.go
@@ -59,6 +59,12 @@ func (s *Server) handleWriteCommandRequest(req sdkModel.CommandRequest,
 		},
 	}
 
+	if s.client == nil {
+		if err := s.Connect(); err != nil {
+			return fmt.Errorf("Driver.handleWriteCommands: client not initialized: %s", err)
+		}
+	}
+
 	resp, err := s.client.Write(s.client.ctx, request)
 	if err != nil {
 		s.sdk.LoggingClient().Errorf("Driver.handleWriteCommands: Write value %v failed: %s", v, err)


### PR DESCRIPTION
# Changes

- retry connection after device update or startup renders client connection invalid
- update unit tests for better coverage with this case
- refactor method handler api endpoint to use echo and return correct HTTP status codes

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions

<!-- How can the reviewers test your change? -->
Toggle device service in a running system (to test with AddDevice)
- with and without valid connections; modify after service is started to trigger UpdateDevice
- with and without auto events; add/remove after service is started to trigger UpdateDevice and ReadHandler
- with and without subscriptions to use SubscriptionHandler
- write command value to trigger WriteHandler
- send method request to trigger MethodHandler
- in locked/unlocked, up/down states
- \+ various combinations of the previous test items
