### PR TITLE
fix: Attempt reconnect if connection is lost

### DIFF
--- a/internal/server/methodhandler.go
+++ b/internal/server/methodhandler.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/ua"
 )
 
@@ -60,7 +61,7 @@ func (s *Server) makeMethodCall(resource models.DeviceResource, parameters []str
 		InputArguments: inputs,
 	}
 
-	if s.client == nil {
+	if s.client == nil || s.client.State() == opcua.Closed || s.client.State() == opcua.Disconnected {
 		if err := s.Connect(); err != nil {
 			return nil, fmt.Errorf("Server.makeMethodCall: client not initialized: %s", err)
 		}

--- a/internal/server/readhandler.go
+++ b/internal/server/readhandler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/edgexfoundry/device-opcua-go/pkg/result"
 	sdkModel "github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
+	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/ua"
 )
 
@@ -54,7 +55,7 @@ func (s *Server) makeReadRequest(req sdkModel.CommandRequest) (*sdkModel.Command
 		TimestampsToReturn: ua.TimestampsToReturnBoth,
 	}
 
-	if s.client == nil {
+	if s.client == nil || s.client.State() == opcua.Closed || s.client.State() == opcua.Disconnected {
 		if err := s.Connect(); err != nil {
 			return nil, fmt.Errorf("Driver.handleReadCommands: client not initialized: %s", err)
 		}

--- a/internal/server/writehandler.go
+++ b/internal/server/writehandler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/edgexfoundry/device-opcua-go/pkg/command"
 	sdkModel "github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
+	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/ua"
 )
 
@@ -59,7 +60,7 @@ func (s *Server) handleWriteCommandRequest(req sdkModel.CommandRequest,
 		},
 	}
 
-	if s.client == nil {
+	if s.client == nil || s.client.State() == opcua.Closed || s.client.State() == opcua.Disconnected {
 		if err := s.Connect(); err != nil {
 			return fmt.Errorf("Driver.handleWriteCommands: client not initialized: %s", err)
 		}


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->
Attempts to reconnect the client and server if the connection is lost.
<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A
<!-- link to docs PR -->

## Testing Instructions

<!-- How can the reviewers test your change? -->
- Run the service with device configuration, see that data is collected.
- Stop the associated server device
- Add a new device instance with proper connection parameters
- Start the server, see data is collected from both devices

## New Dependency Instructions (If applicable)
N/A
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
