### PR TITLE
refactor(readhandler): Group multiple nodes into a single request

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,9 @@ jobs:
           tags: device-opcua:${{ github.sha }}
           load: true
       - name: Scan with Trivy
-        uses: aquasecurity/trivy-action@0.19.0
+        uses: aquasecurity/trivy-action@0.26.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}
         with:
           image-ref: device-opcua:${{ github.sha }}
           format: table

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.26.0
         env:
           GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          TRIVY_DISABLE_VEX_NOTICE: "true"
         with:
           image-ref: device-opcua:${{ github.sha }}
           format: table

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM golang:1.21-alpine3.20 AS builder
+FROM golang:1.22-alpine3.20 AS builder
 WORKDIR /device-opcua-go
 
 # Install our build time packages.
@@ -23,7 +23,7 @@ ARG ADD_BUILD_TAGS=""
 RUN make -e ADD_BUILD_TAGS="$ADD_BUILD_TAGS" build
 
 # Next image - Copy built Go binary into new workspace
-FROM alpine:3.20.0
+FROM alpine:3.20.3
 
 # dumb-init needed for injected secure bootstrapping entrypoint script when run in secure mode.
 # upgrade required to patch for open CVEs.

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run:
 docker: $(DOCKERS)
 
 docker_device_opcua_go:
-	docker build \
+	docker buildx build --pull \
 		--label "git_sha=$(GIT_SHA)" \
 		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
 		-t edgexfoundry/device-opcua-go:$(VERSION)-dev \

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/edgexfoundry/device-opcua-go/internal/server"
 	"github.com/edgexfoundry/device-sdk-go/v3/pkg/interfaces"
@@ -135,7 +136,11 @@ func (d *Driver) Stop(force bool) error {
 func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]models.ProtocolProperties,
 	reqs []sdkModel.CommandRequest) ([]*sdkModel.CommandValue, error) {
 
-	d.sdk.LoggingClient().Debugf("Driver.HandleReadCommands: protocols: %v resource: %v attributes: %v", protocols, reqs[0].DeviceResourceName, reqs[0].Attributes)
+	startTime := time.Now()
+
+	defer func() {
+		d.sdk.LoggingClient().Debugf("Driver.HandleReadCommands (%v)", time.Since(startTime))
+	}()
 
 	s, ok := d.serverMap[deviceName]
 	if !ok {

--- a/internal/server/readhandler.go
+++ b/internal/server/readhandler.go
@@ -53,8 +53,7 @@ func buildNodesToReadRequest(reqs []sdkModel.CommandRequest) (nodesToRead []*ua.
 
 	for reqIndex, req := range reqs {
 		if _, isMethod := req.Attributes[METHOD]; isMethod {
-			err := fmt.Errorf("not allowed to call command on method: %s", req.DeviceResourceName)
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("not allowed to call command on method: %s", req.DeviceResourceName)
 		}
 
 		id, err := getNodeID(req.Attributes, NODE)

--- a/internal/server/readhandler.go
+++ b/internal/server/readhandler.go
@@ -13,66 +13,99 @@ import (
 
 	"github.com/edgexfoundry/device-opcua-go/pkg/result"
 	sdkModel "github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/ua"
 )
 
-func (s *Server) ProcessReadCommands(reqs []sdkModel.CommandRequest) ([]*sdkModel.CommandValue, error) {
-	var responses = make([]*sdkModel.CommandValue, len(reqs))
+type ResultToRequest map[int][]int
 
-	for i, req := range reqs {
-		res, err := s.handleReadCommandRequest(req)
+func (rr ResultToRequest) buildCommandValues(reqs []sdkModel.CommandRequest, resp *ua.ReadResponse, logger logger.LoggingClient) []*sdkModel.CommandValue {
+	responses := make([]*sdkModel.CommandValue, len(reqs))
+	for i := 0; i < len(resp.Results); i++ {
+		if resp.Results[i].Status != ua.StatusOK {
+			logger.Debugf("Driver.handleReadCommands: Status not OK: %v", resp.Results[i].Status)
+			continue
+		}
+
+		variant := resp.Results[i].Value
+		if variant == nil || variant.Value() == nil {
+			continue
+		}
+
+		if reqIndexes, ok := rr[i]; ok {
+			for _, reqIndex := range reqIndexes {
+				var err error
+				if responses[reqIndex], err = result.NewResult(reqs[i], variant.Value()); err != nil {
+					logger.Errorf("Driver.handleReadCommands: Error: %v", err)
+				}
+			}
+		}
+	}
+
+	return responses
+}
+
+func buildNodesToReadRequest(reqs []sdkModel.CommandRequest) (nodesToRead []*ua.ReadValueID, resultToRequest ResultToRequest, err error) {
+	nodesToRead = make([]*ua.ReadValueID, 0, len(reqs))
+	resultToRequest = make(map[int][]int, len(reqs))
+	nodesIdToResultIndex := make(map[string]int, len(reqs))
+
+	for reqIndex, req := range reqs {
+		if _, isMethod := req.Attributes[METHOD]; isMethod {
+			err := fmt.Errorf("not allowed to call command on method: %s", req.DeviceResourceName)
+			return nil, nil, err
+		}
+
+		id, err := getNodeID(req.Attributes, NODE)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Driver.handleReadCommands: Invalid node id = %v", err)
+		}
+
+		if resultIndex, ok := nodesIdToResultIndex[id.String()]; ok {
+			resultToRequest[resultIndex] = append(resultToRequest[resultIndex], reqIndex)
+		} else {
+			nodesToRead = append(nodesToRead, &ua.ReadValueID{NodeID: id})
+			resultIndex = len(nodesToRead) - 1
+			nodesIdToResultIndex[id.String()] = resultIndex
+			resultToRequest[resultIndex] = []int{reqIndex}
+		}
+	}
+
+	return nodesToRead, resultToRequest, nil
+}
+
+func (s *Server) ProcessReadCommands(reqs []sdkModel.CommandRequest) (responses []*sdkModel.CommandValue, err error) {
+	responses = make([]*sdkModel.CommandValue, len(reqs))
+
+	nodesToRead, resultToRequest, err := buildNodesToReadRequest(reqs)
+	if err != nil {
+		s.sdk.LoggingClient().Error(err.Error())
+		return responses, err
+	}
+
+	request := &ua.ReadRequest{
+		MaxAge:             2000,
+		NodesToRead:        nodesToRead,
+		TimestampsToReturn: ua.TimestampsToReturnBoth,
+	}
+
+	if len(request.NodesToRead) > 0 {
+		if s.client == nil || s.client.State() == opcua.Closed || s.client.State() == opcua.Disconnected {
+			if err := s.Connect(); err != nil {
+				s.sdk.LoggingClient().Errorf("Driver.handleReadCommands: client not initialized: %v", err)
+				return responses, err
+			}
+		}
+
+		resp, err := s.client.Read(s.client.ctx, request)
 		if err != nil {
 			s.sdk.LoggingClient().Errorf("Driver.HandleReadCommands: Handle read commands failed: %v", err)
 			return responses, err
 		}
-		s.sdk.LoggingClient().Infof("Read command finished: %v", res)
-		responses[i] = res
+
+		responses = resultToRequest.buildCommandValues(reqs, resp, s.sdk.LoggingClient())
 	}
 
 	return responses, nil
-}
-
-func (s *Server) handleReadCommandRequest(req sdkModel.CommandRequest) (*sdkModel.CommandValue, error) {
-	if _, isMethod := req.Attributes[METHOD]; isMethod {
-		return nil, fmt.Errorf("not allowed to call command on method: %s", req.DeviceResourceName)
-	}
-
-	return s.makeReadRequest(req)
-}
-
-func (s *Server) makeReadRequest(req sdkModel.CommandRequest) (*sdkModel.CommandValue, error) {
-	id, err := getNodeID(req.Attributes, NODE)
-	if err != nil {
-		return nil, fmt.Errorf("Driver.handleReadCommands: Invalid node id = %v", err)
-	}
-
-	request := &ua.ReadRequest{
-		MaxAge: 2000,
-		NodesToRead: []*ua.ReadValueID{
-			{NodeID: id},
-		},
-		TimestampsToReturn: ua.TimestampsToReturnBoth,
-	}
-
-	if s.client == nil || s.client.State() == opcua.Closed || s.client.State() == opcua.Disconnected {
-		if err := s.Connect(); err != nil {
-			return nil, fmt.Errorf("Driver.handleReadCommands: client not initialized: %s", err)
-		}
-	}
-
-	resp, err := s.client.Read(s.client.ctx, request)
-	if err != nil {
-		return nil, fmt.Errorf("Driver.handleReadCommands: Read failed: %s", err)
-	}
-	if resp.Results[0].Status != ua.StatusOK {
-		return nil, fmt.Errorf("Driver.handleReadCommands: Status not OK: %v", resp.Results[0].Status)
-	}
-
-	variant := resp.Results[0].Value
-	if variant == nil {
-		return nil, fmt.Errorf("Driver.handleReadCommands: Variant value is nil")
-	}
-
-	return result.NewResult(req, variant.Value())
 }


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->
Improves read performance by grouping resources in commands into a single OPC UA request.

Special thanks to @syoliver for providing a majority of the necessary modifications.
<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions
- Run EdgeX Foundry and device-opcua service as normal
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
N/A
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
