### PR TITLE
fix(readhandler): Avoid reading the same node multiple times

### DIFF
--- a/internal/server/readhandler.go
+++ b/internal/server/readhandler.go
@@ -20,6 +20,14 @@ import (
 
 type ResultToRequest map[int][]int
 
+func createResult(req sdkModel.CommandRequest, variant *ua.Variant, logger logger.LoggingClient) (response *sdkModel.CommandValue) {
+	var err error
+	if response, err = result.NewResult(req, variant.Value()); err != nil {
+		logger.Errorf("Driver.handleReadCommands: Error: %v", err)
+	}
+	return response
+}
+
 func (rr ResultToRequest) buildCommandValues(reqs []sdkModel.CommandRequest, resp *ua.ReadResponse, logger logger.LoggingClient) []*sdkModel.CommandValue {
 	responses := make([]*sdkModel.CommandValue, len(reqs))
 	for i := 0; i < len(resp.Results); i++ {
@@ -35,10 +43,7 @@ func (rr ResultToRequest) buildCommandValues(reqs []sdkModel.CommandRequest, res
 
 		if reqIndexes, ok := rr[i]; ok {
 			for _, reqIndex := range reqIndexes {
-				var err error
-				if responses[reqIndex], err = result.NewResult(reqs[i], variant.Value()); err != nil {
-					logger.Errorf("Driver.handleReadCommands: Error: %v", err)
-				}
+				responses[reqIndex] = createResult(reqs[reqIndex], variant, logger)
 			}
 		}
 	}

--- a/internal/server/readhandler_test.go
+++ b/internal/server/readhandler_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/edgexfoundry/device-opcua-go/internal/test"
 	sdkModel "github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 	"github.com/gopcua/opcua"
@@ -441,4 +442,113 @@ func TestBuildReadRequestOnMissingNodeId(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Node Id is missing from properties; error expected")
 	}
+}
+
+func TestBuildCommandValues(t *testing.T) {
+	reqs := []sdkModel.CommandRequest{
+		{
+			DeviceResourceName: "Res1",
+			Type:               common.ValueTypeInt32,
+		},
+		{
+			DeviceResourceName: "Res2",
+			Type:               common.ValueTypeInt32,
+		},
+		{
+			DeviceResourceName: "Res3",
+			Type:               common.ValueTypeInt32,
+		},
+	}
+
+	lc := logger.NewMockClient()
+
+	t.Run("Read on one node", func(t *testing.T) {
+		var resultToRequest ResultToRequest = map[int][]int{0: {0, 1, 2}}
+
+		uaResponse := &ua.ReadResponse{
+			Results: []*ua.DataValue{
+				{
+					Value: ua.MustVariant(int32(1)),
+				},
+			},
+		}
+
+		commandValues := resultToRequest.buildCommandValues(reqs, uaResponse, lc)
+
+		if len(commandValues) != 3 {
+			t.Fatalf("Expected number of command values 3; got %d;", len(commandValues))
+		}
+
+		if commandValues[0].DeviceResourceName != "Res1" {
+			t.Fatalf("Expected device resource name [0] Res1; got %s", commandValues[0].DeviceResourceName)
+		}
+
+		if commandValues[1].DeviceResourceName != "Res2" {
+			t.Fatalf("Expected device resource name [1] Res2; got %s", commandValues[1].DeviceResourceName)
+		}
+
+		if commandValues[2].DeviceResourceName != "Res3" {
+			t.Fatalf("Expected device resource name [2] Res3; got %s", commandValues[2].DeviceResourceName)
+		}
+
+		if commandValues[0].Value != int32(1) {
+			t.Fatalf("Expected device resource value [0] 1; got %v", commandValues[0].Value)
+		}
+
+		if commandValues[1].Value != int32(1) {
+			t.Fatalf("Expected device resource value [1] 1; got %v", commandValues[1].Value)
+		}
+
+		if commandValues[2].Value != int32(1) {
+			t.Fatalf("Expected device resource value [2] 1; got %v", commandValues[2].Value)
+		}
+
+	})
+
+	t.Run("Read on multiple nodes", func(t *testing.T) {
+		var resultToRequest ResultToRequest = map[int][]int{0: {0}, 1: {1}, 2: {2}}
+
+		uaResponse := &ua.ReadResponse{
+			Results: []*ua.DataValue{
+				{
+					Value: ua.MustVariant(int32(1)),
+				}, {
+					Value: ua.MustVariant(int32(2)),
+				}, {
+					Value: ua.MustVariant(int32(3)),
+				},
+			},
+		}
+
+		commandValues := resultToRequest.buildCommandValues(reqs, uaResponse, lc)
+
+		if len(commandValues) != 3 {
+			t.Fatalf("Expected number of command values 3; got %d;", len(commandValues))
+		}
+
+		if commandValues[0].DeviceResourceName != "Res1" {
+			t.Fatalf("Expected device resource name [0] Res1; got %s", commandValues[0].DeviceResourceName)
+		}
+
+		if commandValues[1].DeviceResourceName != "Res2" {
+			t.Fatalf("Expected device resource name [1] Res2; got %s", commandValues[1].DeviceResourceName)
+		}
+
+		if commandValues[2].DeviceResourceName != "Res3" {
+			t.Fatalf("Expected device resource name [2] Res3; got %s", commandValues[2].DeviceResourceName)
+		}
+
+		if commandValues[0].Value != int32(1) {
+			t.Fatalf("Expected device resource value [0] 1; got %v", commandValues[0].Value)
+		}
+
+		if commandValues[1].Value != int32(2) {
+			t.Fatalf("Expected device resource value [1] 2; got %v", commandValues[1].Value)
+		}
+
+		if commandValues[2].Value != int32(3) {
+			t.Fatalf("Expected device resource value [2] 3; got %v", commandValues[2].Value)
+		}
+
+	})
 }


### PR DESCRIPTION
The incorrect index was being used when populating the `responses` slice.

Thank you @syoliver for this fix.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions

<!-- How can the reviewers test your change? -->
See unit tests

## New Dependency Instructions (If applicable)

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
