### PR TITLE
fix: Revert mistaken api version change

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -43,7 +43,7 @@ func (d *Driver) Initialize(sdk interfaces.DeviceServiceSDK) error {
 	d.sdk = sdk
 
 	// Define custom API endpoints
-	if err := d.sdk.AddCustomRoute("/api/v4/call", interfaces.Authenticated, handleMethodCall, http.MethodPost); err != nil {
+	if err := d.sdk.AddCustomRoute("/api/v3/call", interfaces.Authenticated, handleMethodCall, http.MethodPost); err != nil {
 		return fmt.Errorf("unable to add custom route to device service: %v", err)
 	}
 

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -196,7 +196,7 @@ func TestDriver_Initialize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d, dsMock := newMockDriver(t)
-			dsMock.On("AddCustomRoute", "/api/v4/call", mock.Anything, mock.AnythingOfType("func(echo.Context) error"), http.MethodPost).Return(tt.err)
+			dsMock.On("AddCustomRoute", "/api/v3/call", mock.Anything, mock.AnythingOfType("func(echo.Context) error"), http.MethodPost).Return(tt.err)
 			if tt.err == nil {
 				dsMock.On("Devices").Return(tt.devices)
 			}


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

In the previous PR, the `/api/` version was mistakenly changed from `/v3` to `/v4`. This PR reverts that change.

Additionally, the `README` file was updated to account for the modification of services in EdgeX Foundry v4.

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions

<!-- How can the reviewers test your change? -->
If you want to test with the secure mode:
1. `make gen ds-opc-ua` with edgex-compose
2. Replace image and references of `device-opc-ua` with `device-opcua`
3. `make get-token` with edgex-compose
4. Log into http://localhost:4000 with the token
5. Start simulation server and update the device endpoint to your PC's address
6. Check the device service logs or stream events in the DataCenter

## New Dependency Instructions (If applicable)

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
