### PR TITLE
chore(dependabot): Add options for cooldown and grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,36 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    cooldown:
+      default-days: 14
+    groups:
+      edgex-foundry-dependencies:
+        applies-to: version-updates
+        patterns:
+          - github.com/edgexfoundry/*
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
+    cooldown:
+      default-days: 14
+    groups:
+      actions-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
   # Maintain Docker base images
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
+    cooldown:
+      default-days: 14
+    groups:
+      docker-base-images:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,15 @@ updates:
       actions-dependencies:
         applies-to: version-updates
         patterns:
-          - "*"
+          - actions/*
+      docker-dependencies:
+        applies-to: version-updates
+        patterns:
+          - docker/*
+      security-dependencies:
+        applies-to: version-updates
+        patterns:
+          - aquasecurity/*
   # Maintain Docker base images
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
Due to the recent supply chain attacks that have been happening across GitHub, I'm applying this small safety net to our dependabot options which does the following:
- Sets a `cooldown` timer for new packages; packages younger than the `cooldown` days will not be included in an update

Additionally, to limit the number of PRs opened, the following change has also been made:
- Applied `groups` option; prevents opening individual PRs for updates in certain scenarios
  - Docker updates will be grouped into their own respective PRs
  - GitHub Actions updates will be split between owner organizations and grouped into their own respective PRs
  - Go module updates related to EdgeXFoundry will be grouped into their own PR
  - Other Go module updates will continue to receive their own PRs.
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions

<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
